### PR TITLE
Add Gruntfile.js to the list of copyOnly files

### DIFF
--- a/themes.profile.js
+++ b/themes.profile.js
@@ -4,7 +4,8 @@ var profile = (function(){
 		copyOnly = function(filename, mid){
 			var list = {
 				"themes/themes.profile":1,
-				"themes/package.json":1
+				"themes/package.json":1,
+				"themes/Gruntfile":1
 			};
 			return (mid in list) || (/^dijit\/resources\//.test(mid) && !/\.css$/.test(filename)) || /(png|jpg|jpeg|gif|tiff)$/.test(filename);
 		};


### PR DESCRIPTION
Using the themes in a Dojo build results in an error:

error(307) Failed to evaluate module tagged as pure AMD (fell back to processing with regular expressions).
module: themes/Gruntfile; error: ReferenceError: module is not defined

Adding Gruntfile.js to the list of copyOnly removes it from the files marked as AMD. This fixes the issue and a Dojo build can be made with the flat theme.
