### PR TITLE
Fix `dijit/Calendar` flat theme styles for 1.11+

### DIFF
--- a/flat/dijit/Calendar.css
+++ b/flat/dijit/Calendar.css
@@ -69,14 +69,14 @@
 }
 .flat .dijitCalendarDecrementArrow {
   float: left;
-  padding-left: 4px/2;
+  padding-left: 2px;
 }
 .flat .dijitCalendarDecrementArrow:before {
   content: "\f000";
 }
 .flat .dijitCalendarIncrementArrow {
   float: right;
-  padding-right: 4px/2;
+  padding-right: 2px;
 }
 .flat .dijitCalendarIncrementArrow:before {
   content: "\f001";

--- a/flat/dijit/Calendar.css
+++ b/flat/dijit/Calendar.css
@@ -1,17 +1,17 @@
 /* Calendar
- * 
+ *
  * Styling Calendar mainly includes:
- * 
+ *
  * 1. Calendar container
  * 		.dijitCalendar - main container
  * 		.dijitCalendarHover / .dijitCalendarActive - states e.g. hover,active
- * 
+ *
  * 2. Month
  * 		.dijitCalendarMonthContainer
  * 		.dijitCalendarMonthLabel
  *      .dijitCalendarDecrease / .dijitCalendarDecrease - icons for switching to previous/next month
  *      .dijitCalendarArrowActive .dijitCalendarDecrease - states e.g. hover,active
- * 
+ *
  * 3. Date
  * 		.dijitCalendarDayLabelTemplate - week day column header e.g. S M T W T F S
  * 		.dijitCalendarDateTemplate - date label wrapper
@@ -19,15 +19,15 @@
  *      .dijitCalendarSelectedDate .dijitCalendarDateLabel - styles for selected date
  * 		.dijitCalendarDisabledDate .dijitCalendarDateLabel - styles for disabled date
  * 		.dijitCalendarActiveDate .dijitCalendarDateLabel - states e.g. hover,active
- * 
+ *
  * 4. Year
  * 		.dijitCalendarYearContainer
  * 		.dijitCalendarYearLabel
  * 		.dijitCalendarPreviousYear /.dijitCalendarNextYear
  *      .dijitCalendarNextYearHover / .dijitCalendarPreviousYearHover - states e.g. hover,active
- *      
+ *
  * 5. Dropdown Month Menu
- * 		.dijitCalendarMonthMenu - menu container     
+ * 		.dijitCalendarMonthMenu - menu container
  * 		.dijitCalendarMonthMenu .dijitCalendarMonthLabel - month label in menu item
  * 		.dijitCalendarMonthMenu .dijitCalendarMonthLabelHover - menu item hover state
  */
@@ -47,7 +47,7 @@
   vertical-align: middle;
   margin: 4px 0;
 }
-.flat .dijitCalendarIncrementControl {
+.flat .dijitCalendarArrow {
   font-family: "flat-icon";
   speak: none;
   font-style: normal;
@@ -58,14 +58,27 @@
   font-size: 16px;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  cursor: pointer;
   font-size: 24px;
   border: 1px solid transparent;
   padding: 4px;
 }
-.flat .dijitCalendarDecrease:before {
+.flat .dijitCalendarDecrease,
+.flat .dijitCalendarIncrease {
+  display: none;
+}
+.flat .dijitCalendarDecrementArrow {
+  float: left;
+  padding-left: 4px/2;
+}
+.flat .dijitCalendarDecrementArrow:before {
   content: "\f000";
 }
-.flat .dijitCalendarIncrease:before {
+.flat .dijitCalendarIncrementArrow {
+  float: right;
+  padding-right: 4px/2;
+}
+.flat .dijitCalendarIncrementArrow:before {
   content: "\f001";
 }
 .flat .dijitCalendarArrowHover .dijitCalendarIncrementControl,

--- a/flat/dijit/Calendar.styl
+++ b/flat/dijit/Calendar.styl
@@ -71,7 +71,7 @@
 
 	.dijitCalendarDecrementArrow {
 		float: left;
-		padding-left: $padding / 2;
+		padding-left: ($padding / 2);
 
 		&:before {
 			content: $calendar-icon-decrease;
@@ -80,7 +80,7 @@
 
 	.dijitCalendarIncrementArrow {
 		float: right;
-		padding-right: $padding / 2;
+		padding-right: ($padding / 2);
 
 		&:before {
 			content: $calendar-icon-increase;

--- a/flat/dijit/Calendar.styl
+++ b/flat/dijit/Calendar.styl
@@ -1,17 +1,17 @@
 /* Calendar
- * 
+ *
  * Styling Calendar mainly includes:
- * 
+ *
  * 1. Calendar container
  * 		.dijitCalendar - main container
  * 		.dijitCalendarHover / .dijitCalendarActive - states e.g. hover,active
- * 
+ *
  * 2. Month
  * 		.dijitCalendarMonthContainer
  * 		.dijitCalendarMonthLabel
  *      .dijitCalendarDecrease / .dijitCalendarDecrease - icons for switching to previous/next month
  *      .dijitCalendarArrowActive .dijitCalendarDecrease - states e.g. hover,active
- * 
+ *
  * 3. Date
  * 		.dijitCalendarDayLabelTemplate - week day column header e.g. S M T W T F S
  * 		.dijitCalendarDateTemplate - date label wrapper
@@ -19,15 +19,15 @@
  *      .dijitCalendarSelectedDate .dijitCalendarDateLabel - styles for selected date
  * 		.dijitCalendarDisabledDate .dijitCalendarDateLabel - styles for disabled date
  * 		.dijitCalendarActiveDate .dijitCalendarDateLabel - states e.g. hover,active
- * 
+ *
  * 4. Year
  * 		.dijitCalendarYearContainer
  * 		.dijitCalendarYearLabel
  * 		.dijitCalendarPreviousYear /.dijitCalendarNextYear
  *      .dijitCalendarNextYearHover / .dijitCalendarPreviousYearHover - states e.g. hover,active
- *      
+ *
  * 5. Dropdown Month Menu
- * 		.dijitCalendarMonthMenu - menu container     
+ * 		.dijitCalendarMonthMenu - menu container
  * 		.dijitCalendarMonthMenu .dijitCalendarMonthLabel - month label in menu item
  * 		.dijitCalendarMonthMenu .dijitCalendarMonthLabelHover - menu item hover state
  */
@@ -55,20 +55,33 @@
 
 	/* next/previous month arrows */
 
-	.dijitCalendarIncrementControl {
+	.dijitCalendarArrow {
 		_icon-core-style();
+		cursor: pointer;
 		font-size: $calendar-icon-size;
 		border: 1px solid transparent;
 		padding: $padding;
 	}
 
-	.dijitCalendarDecrease {
+	// Since the arrow icons are pulled from the font, the `img` tags are not needed.
+	.dijitCalendarDecrease,
+	.dijitCalendarIncrease {
+		display: none;
+	}
+
+	.dijitCalendarDecrementArrow {
+		float: left;
+		padding-left: $padding / 2;
+
 		&:before {
 			content: $calendar-icon-decrease;
 		}
 	}
 
-	.dijitCalendarIncrease {
+	.dijitCalendarIncrementArrow {
+		float: right;
+		padding-right: $padding / 2;
+
 		&:before {
 			content: $calendar-icon-increase;
 		}
@@ -156,7 +169,7 @@
 	}
 
 	/* selected */
-		
+
 	.dijitCalendarSelectedDate,
 	.dijitCalendarSelectedDate.dijitCalendarHoveredDate {
 		 .dijitCalendarDateLabel {
@@ -166,7 +179,7 @@
 	}
 
 	/* disabled */
-	
+
 	.dijitCalendarDisabledDate .dijitCalendarDateLabel {
 		opacity: $disabled-opacity;
 	}
@@ -230,5 +243,5 @@
 			background-color: $calendar-month-dropdown-menu-item-hovered-background-color;
 		}
 	}
-	
+
 }

--- a/flat/tests/flat.html
+++ b/flat/tests/flat.html
@@ -446,7 +446,7 @@ body {
 		</div>
 	</div>
 </div>
-<script src="//ajax.googleapis.com/ajax/libs/dojo/1.10.4/dojo/dojo.js"></script>
+<script src="//ajax.googleapis.com/ajax/libs/dojo/1.12.1/dojo/dojo.js"></script>
 <script>
 var continentStore, continentModel, menu, showDialog;
 require([

--- a/flat/tests/flat.html
+++ b/flat/tests/flat.html
@@ -446,7 +446,7 @@ body {
 		</div>
 	</div>
 </div>
-<script src="//ajax.googleapis.com/ajax/libs/dojo/1.12.1/dojo/dojo.js"></script>
+<script src="//archive.dojotoolkit.org/cdn/1.12.2-cdn/1.12.2/dojo/dojo.js"></script>
 <script>
 var continentStore, continentModel, menu, showDialog;
 require([


### PR DESCRIPTION
Resolves #38, and also resolves #36.

Update the theme tester to use Dojo 1.12.1, and update the flat theme styles for `dijit/Calendar` to correctly render the previous/next arrows. 